### PR TITLE
Speed up touchscreen scrolling with drag multiplier and momentum inertia

### DIFF
--- a/style.css
+++ b/style.css
@@ -1004,6 +1004,27 @@
    ══════════════════════════════════════════════ */
 
 @media (pointer: coarse) {
+    /* ── Enable momentum scrolling on content areas ── */
+
+    .chat-manager-content {
+        -webkit-overflow-scrolling: touch;
+        overscroll-behavior-y: contain;
+        scroll-behavior: smooth;
+    }
+
+    .chat-manager-popup .chat-manager-content {
+        -webkit-overflow-scrolling: touch;
+        overscroll-behavior-y: contain;
+    }
+
+    .chat-manager-timeline-popup {
+        -webkit-overflow-scrolling: touch;
+    }
+
+    .chat-manager-timeline-tooltip {
+        -webkit-overflow-scrolling: touch;
+    }
+
     /* ── Always show hover-dependent actions on touch ── */
 
     .chat-manager-card-actions {


### PR DESCRIPTION
Apply a 1.8x speed multiplier to touch drag panning so each swipe covers
more distance. Add momentum/inertia physics on finger lift so the viewport
continues drifting and gradually decelerates, matching native touch scroll
feel. Also enable -webkit-overflow-scrolling and overscroll-behavior for
the panel content areas on coarse-pointer devices.

https://claude.ai/code/session_01Qcdfe4i1cVpjJ2cooriBQt