### PR TITLE
Add failed generation sound alert

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,13 +11,14 @@ import {
 } from './src/ui-controller.js';
 import {
     getDisplayMode, setDisplayMode, getBranchContextEnabled, getAIConnectionProfile, setAIConnectionProfile,
-    getEmbeddingSettings, setEmbeddingSettings,
+    getEmbeddingSettings, setEmbeddingSettings, getFailureAlertEnabled, setFailureAlertEnabled,
 } from './src/metadata-store.js';
 import { updateBranchContextInjection, clearBranchContextInjection } from './src/branch-context.js';
 import { attachMomentumScroll } from './src/momentum-scroll.js';
 import { acknowledgeEmbeddingModelChange, clearEmbeddingCache, getCacheStats } from './src/embedding-service.js';
 import { updateGraphViewData, isGraphViewMounted } from './src/graph-view.js';
 import { resolveActiveChatFilename } from './src/active-chat.js';
+import { initGenerationFailureAlert, primeFailureAlertAudio } from './src/generation-failure-alert.js';
 
 const MODULE_NAME = 'chat_manager';
 const EXTENSION_PATH = '/scripts/extensions/third-party/chat_manager';
@@ -115,6 +116,13 @@ const onMessageUpdate = (() => {
 
     // Listen for SillyTavern events
     if (eventSource && eventTypes) {
+        initGenerationFailureAlert({
+            eventSource,
+            eventTypes,
+            getContext: () => SillyTavern.getContext(),
+            isEnabled: getFailureAlertEnabled,
+        });
+
         eventSource.on(eventTypes.CHAT_CHANGED, onChatChanged);
         eventSource.on(eventTypes.MESSAGE_SENT, onMessageUpdate);
         eventSource.on(eventTypes.MESSAGE_RECEIVED, onMessageUpdate);
@@ -443,6 +451,25 @@ function formatCacheStatsLine(stats) {
     const count = Number.isFinite(stats?.count) ? stats.count : 0;
     const sizeKB = Number.isFinite(stats?.estimatedSizeKB) ? stats.estimatedSizeKB : 0;
     return `${count} vectors, ~${sizeKB.toFixed(1)} KB`;
+}
+
+/**
+ * Bind the failed generation sound toggle.
+ * @param {HTMLElement} container
+ */
+function bindFailureAlertSettingsUI(container) {
+    const toggle = container.querySelector('#chat-manager-failure-alert-enabled');
+    if (!toggle) return;
+
+    toggle.checked = getFailureAlertEnabled();
+    toggle.addEventListener('change', () => {
+        setFailureAlertEnabled(toggle.checked);
+        if (toggle.checked) {
+            // The change event is a user gesture, making it the reliable moment
+            // to unlock Web Audio for later background failures.
+            void primeFailureAlertAudio();
+        }
+    });
 }
 
 /**
@@ -1066,6 +1093,7 @@ async function injectSettingsPanel() {
         const aiProfileSelect = container.querySelector('#chat-manager-ai-profile');
         bindAIProfileDropdown(aiProfileSelect);
 
+        bindFailureAlertSettingsUI(container);
         bindEmbeddingSettingsUI(container);
     })().finally(() => {
         pendingSettingsInjection = null;

--- a/src/generation-failure-alert.js
+++ b/src/generation-failure-alert.js
@@ -1,0 +1,233 @@
+/**
+ * Generation Failure Alert — Detect failed foreground response generations and
+ * play a short, self-contained Web Audio alert.
+ *
+ * SillyTavern does not expose a dedicated GENERATION_FAILED event. Detection
+ * therefore combines its generation lifecycle, response, and stop events with
+ * visible error toasts. A short settle delay lets the manual-stop event arrive
+ * after GENERATION_ENDED before a missing response is classified as a failure.
+ */
+
+const RESPONSE_GENERATION_TYPES = new Set(['normal', 'regenerate', 'swipe', 'continue']);
+const FAILURE_SETTLE_DELAY_MS = 180;
+const ATTEMPT_EXPIRY_MS = 15 * 60 * 1000;
+
+let audioContext = null;
+let currentAttempt = null;
+let attemptSequence = 0;
+let toastObserver = null;
+let audioWarningShown = false;
+
+function getAudioContext() {
+    if (audioContext) return audioContext;
+
+    const AudioContextClass = globalThis.AudioContext || globalThis.webkitAudioContext;
+    if (!AudioContextClass) return null;
+
+    audioContext = new AudioContextClass();
+    return audioContext;
+}
+
+/**
+ * Unlock Web Audio while handling a user gesture (for example, enabling the
+ * toggle). Browsers may otherwise block a sound first requested after an API
+ * call has failed in the background.
+ * @returns {Promise<boolean>}
+ */
+export async function primeFailureAlertAudio() {
+    try {
+        const context = getAudioContext();
+        if (!context) return false;
+        if (context.state === 'suspended') {
+            await context.resume();
+        }
+        return context.state === 'running';
+    } catch (error) {
+        console.warn('[chat_manager] Could not initialize failure alert audio:', error);
+        return false;
+    }
+}
+
+function scheduleTone(context, output, frequency, startOffset, duration) {
+    const oscillator = context.createOscillator();
+    const envelope = context.createGain();
+    const startAt = context.currentTime + startOffset;
+    const endAt = startAt + duration;
+
+    oscillator.type = 'triangle';
+    oscillator.frequency.setValueAtTime(frequency, startAt);
+    oscillator.frequency.exponentialRampToValueAtTime(frequency * 0.82, endAt);
+
+    envelope.gain.setValueAtTime(0.0001, startAt);
+    envelope.gain.exponentialRampToValueAtTime(0.24, startAt + 0.018);
+    envelope.gain.exponentialRampToValueAtTime(0.0001, endAt);
+
+    oscillator.connect(envelope);
+    envelope.connect(output);
+    oscillator.start(startAt);
+    oscillator.stop(endAt + 0.01);
+}
+
+/**
+ * Play a concise descending two-note failure cue.
+ * @returns {Promise<boolean>} Whether playback was scheduled.
+ */
+export async function playFailureAlertSound() {
+    try {
+        const ready = await primeFailureAlertAudio();
+        const context = getAudioContext();
+        if (!ready || !context) return false;
+
+        const output = context.createGain();
+        output.gain.setValueAtTime(0.7, context.currentTime);
+        output.connect(context.destination);
+
+        scheduleTone(context, output, 740, 0, 0.16);
+        scheduleTone(context, output, 440, 0.19, 0.27);
+
+        window.setTimeout(() => output.disconnect(), 650);
+        return true;
+    } catch (error) {
+        if (!audioWarningShown) {
+            audioWarningShown = true;
+            console.warn('[chat_manager] Failed to play generation failure alert:', error);
+        }
+        return false;
+    }
+}
+
+function isErrorToastNode(node) {
+    if (!(node instanceof Element)) return false;
+    return node.matches('.toast-error') || Boolean(node.querySelector('.toast-error'));
+}
+
+function isAttemptCurrent(attempt) {
+    return Boolean(attempt && currentAttempt && attempt.id === currentAttempt.id);
+}
+
+function expireAttempt(attempt) {
+    window.setTimeout(() => {
+        if (isAttemptCurrent(attempt)) {
+            currentAttempt = null;
+        }
+    }, ATTEMPT_EXPIRY_MS);
+}
+
+/**
+ * @param {object} attempt
+ * @param {string} reason
+ * @param {() => boolean} isEnabled
+ */
+function alertForAttempt(attempt, reason, isEnabled) {
+    if (!isAttemptCurrent(attempt) || attempt.alerted || attempt.stopped || !attempt.armed) return;
+    if (!isEnabled()) return;
+
+    attempt.alerted = true;
+    console.warn(`[chat_manager] Response generation failed (${reason}).`);
+    void playFailureAlertSound();
+}
+
+/**
+ * Initialize generation failure detection. Safe to call once during extension
+ * startup; subsequent calls are ignored.
+ *
+ * @param {object} options
+ * @param {object} options.eventSource SillyTavern event emitter
+ * @param {object} options.eventTypes SillyTavern event type map
+ * @param {() => object} options.getContext Returns the current ST context
+ * @param {() => boolean} options.isEnabled Returns the persisted toggle state
+ */
+export function initGenerationFailureAlert({ eventSource, eventTypes, getContext, isEnabled }) {
+    if (!eventSource || !eventTypes || initGenerationFailureAlert.initialized) return;
+    initGenerationFailureAlert.initialized = true;
+
+    const hasAfterCommandsEvent = Boolean(eventTypes.GENERATION_AFTER_COMMANDS);
+
+    // A persisted-on toggle still needs one interaction after a page load to
+    // satisfy browser autoplay policies. Sending a message naturally supplies
+    // that interaction before a later failure.
+    const primeFromUserGesture = () => {
+        if (isEnabled()) {
+            void primeFailureAlertAudio();
+        }
+    };
+    document.addEventListener('pointerdown', primeFromUserGesture, { capture: true, once: true });
+    document.addEventListener('keydown', primeFromUserGesture, { capture: true, once: true });
+
+    eventSource.on(eventTypes.GENERATION_STARTED, (type, _options, dryRun = false) => {
+        if (dryRun || !RESPONSE_GENERATION_TYPES.has(type)) return;
+
+        const attempt = {
+            id: ++attemptSequence,
+            type,
+            armed: !hasAfterCommandsEvent,
+            received: false,
+            stopped: false,
+            alerted: false,
+            streamingFailed: false,
+        };
+        currentAttempt = attempt;
+        expireAttempt(attempt);
+    });
+
+    if (hasAfterCommandsEvent) {
+        eventSource.on(eventTypes.GENERATION_AFTER_COMMANDS, (type, _options, dryRun = false) => {
+            if (!currentAttempt || dryRun || currentAttempt.type !== type) return;
+            currentAttempt.armed = true;
+        });
+    }
+
+    eventSource.on(eventTypes.MESSAGE_RECEIVED, () => {
+        if (currentAttempt) {
+            currentAttempt.received = true;
+        }
+    });
+
+    eventSource.on(eventTypes.GENERATION_STOPPED, () => {
+        if (currentAttempt) {
+            currentAttempt.stopped = true;
+        }
+    });
+
+    eventSource.on(eventTypes.GENERATION_ENDED, () => {
+        const attempt = currentAttempt;
+        if (!attempt || !attempt.armed) return;
+
+        // StreamingProcessor distinguishes a transport/parser failure
+        // (isStopped=true, isFinished=false) from a user stop
+        // (isFinished=true before GENERATION_STOPPED is emitted).
+        const streamingProcessor = getContext()?.streamingProcessor;
+        attempt.streamingFailed = Boolean(
+            streamingProcessor?.isStopped === true && streamingProcessor?.isFinished === false,
+        );
+
+        window.setTimeout(() => {
+            if (!isAttemptCurrent(attempt)) return;
+
+            if (attempt.streamingFailed) {
+                alertForAttempt(attempt, 'streaming error', isEnabled);
+            } else if (!attempt.received && !attempt.stopped) {
+                alertForAttempt(attempt, 'no response received', isEnabled);
+            }
+
+            if (isAttemptCurrent(attempt)) {
+                currentAttempt = null;
+            }
+        }, FAILURE_SETTLE_DELAY_MS);
+    });
+
+    // Core API failures are normally rendered as toastr errors. Observing the
+    // DOM avoids replacing toastr's single global subscriber used by ST itself.
+    toastObserver = new MutationObserver((mutations) => {
+        const attempt = currentAttempt;
+        if (!attempt || !attempt.armed || attempt.stopped) return;
+
+        for (const mutation of mutations) {
+            if (Array.from(mutation.addedNodes).some(isErrorToastNode)) {
+                alertForAttempt(attempt, 'API error', isEnabled);
+                break;
+            }
+        }
+    });
+    toastObserver.observe(document.body, { childList: true, subtree: true });
+}

--- a/src/metadata-store.js
+++ b/src/metadata-store.js
@@ -99,6 +99,9 @@ function ensureSettings() {
     if (extensionSettings[MODULE_NAME].aiConnectionProfile === undefined) {
         extensionSettings[MODULE_NAME].aiConnectionProfile = '';
     }
+    if (extensionSettings[MODULE_NAME].failureAlertEnabled === undefined) {
+        extensionSettings[MODULE_NAME].failureAlertEnabled = false;
+    }
     if (!extensionSettings[MODULE_NAME].embeddings || typeof extensionSettings[MODULE_NAME].embeddings !== 'object') {
         extensionSettings[MODULE_NAME].embeddings = createDefaultEmbeddingSettings();
     }
@@ -396,6 +399,27 @@ export function setAIConnectionProfile(profileId) {
     ensureSettings();
     const { extensionSettings, saveSettingsDebounced } = SillyTavern.getContext();
     extensionSettings[MODULE_NAME].aiConnectionProfile = profileId || '';
+    saveSettingsDebounced();
+}
+
+/**
+ * Get the failed response generation sound preference (defaults to false).
+ * @returns {boolean}
+ */
+export function getFailureAlertEnabled() {
+    ensureSettings();
+    const { extensionSettings } = SillyTavern.getContext();
+    return extensionSettings[MODULE_NAME].failureAlertEnabled === true;
+}
+
+/**
+ * Set the failed response generation sound preference.
+ * @param {boolean} enabled
+ */
+export function setFailureAlertEnabled(enabled) {
+    ensureSettings();
+    const { extensionSettings, saveSettingsDebounced } = SillyTavern.getContext();
+    extensionSettings[MODULE_NAME].failureAlertEnabled = enabled === true;
     saveSettingsDebounced();
 }
 

--- a/style.css
+++ b/style.css
@@ -894,6 +894,22 @@
     border-top: 1px solid rgba(255, 255, 255, 0.08);
 }
 
+.chat-manager-alert-setting {
+    padding: 9px 10px;
+    border: 1px solid rgba(255, 174, 94, 0.22);
+    border-radius: 7px;
+    background: rgba(255, 148, 72, 0.055);
+}
+
+.chat-manager-alert-setting .chat-manager-settings-inline-check {
+    margin-bottom: 5px;
+}
+
+.chat-manager-alert-setting .fa-bell {
+    margin-right: 3px;
+    color: rgba(255, 184, 112, 0.92);
+}
+
 .chat-manager-emb-model-tools {
     display: flex;
     gap: 8px;

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -31,6 +31,18 @@
             </small>
 
             <div class="chat-manager-settings-separator"></div>
+            <label class="chat-manager-settings-label">Alerts</label>
+            <div class="chat-manager-alert-setting">
+                <label class="chat-manager-settings-inline-check" for="chat-manager-failure-alert-enabled">
+                    <input id="chat-manager-failure-alert-enabled" type="checkbox" />
+                    <span><i class="fa-solid fa-bell" aria-hidden="true"></i> Failed generation sound</span>
+                </label>
+                <small class="chat-manager-settings-desc" style="padding-left: 0;">
+                    Plays a descending alert when a response fails or returns an API error. Manual stops are ignored.
+                </small>
+            </div>
+
+            <div class="chat-manager-settings-separator"></div>
             <label class="chat-manager-settings-label">Embeddings</label>
             <label class="chat-manager-settings-inline-check">
                 <input id="chat-manager-emb-enabled" type="checkbox" />


### PR DESCRIPTION
## What changed

- add a persisted **Failed generation sound** toggle to Chat Manager settings
- detect foreground API errors, streaming failures, and generations that end without a response
- play a self-contained descending Web Audio cue once per failed attempt
- keep successful generations and manual stops silent
- prime audio from a user gesture to support background-tab playback within browser autoplay rules

## Why

SillyTavern reports generation failures in the UI but does not provide a dedicated sound or operating-system alert when a response fails. This makes failures easy to miss while the tab is unfocused.

## Implementation notes

SillyTavern does not expose a `GENERATION_FAILED` event, so the extension combines generation lifecycle events, response receipt, live streaming state, and error-toast observation. A short settle delay prevents the event ordering for manual stops from being misclassified as failure.

## Validation

- JavaScript syntax checks for all changed modules
- staged diff whitespace validation
- simulated successful response remains silent
- simulated manual stop remains silent
- simulated streaming failure, missing response, and API-error toast each play one alert
- duplicate-alert suppression verified
- persisted toggle getter/setter verified